### PR TITLE
Bug 1452166 - Create HTTP Edge node that responds with 400 on invalid payloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,121 @@
+# These environment variables must be set in CircleCI UI
+#
+# DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
+# DOCKER_EMAIL   - login info for docker hub
+# DOCKER_USER
+# DOCKER_PASS
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: docker:18.02.0-ce-git
+    working_directory: /edge-validator
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - setup_remote_docker
+
+      - run:
+          name: Create a version.json
+          command: |
+            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "$CIRCLE_SHA1" \
+            "$CIRCLE_TAG" \
+            "$CIRCLE_PROJECT_USERNAME" \
+            "$CIRCLE_PROJECT_REPONAME" \
+            "$CIRCLE_BUILD_URL" > version.json
+      - run:
+          name: Build Docker image
+          command: docker build -t app:build .
+
+      # save the built docker container into CircleCI's cache. This is
+      # required since Workflows do not have the same remote docker instance.
+      - run:
+          name: docker save app:build
+          command: mkdir -p /cache; docker save -o /cache/docker.tar "app:build"
+      - save_cache:
+          key: v1-{{ .Branch }}-{{epoch}}
+          paths:
+            - /cache/docker.tar
+
+  test:
+    docker:
+      - image: docker:18.02.0-ce
+    steps:
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{.Branch}}
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /cache/docker.tar
+
+      - run:
+          name: Test Code
+          command: |
+            mkdir test-reports
+            chown -R 10001:10001 test-reports
+            docker run -v test-reports:/app/ -it app:build \
+              pipenv run \
+                python -m pytest --junitxml=test-reports/junit.xml tests/
+
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: test-reports
+
+  deploy:
+    docker:
+      - image: docker:18.02.0-ce
+    steps:
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-{{.Branch}}
+      - run:
+          name: Restore Docker image cache
+          command: docker load -i /cache/docker.tar
+
+      - run:
+          name: Deploy to Dockerhub
+          command: |
+            # deploy master
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker tag app:build ${DOCKERHUB_REPO}:latest
+              docker push ${DOCKERHUB_REPO}:latest
+            elif  [ ! -z "${CIRCLE_TAG}" ]; then
+            # deploy a release tag...
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              docker tag app:build "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              docker images
+              docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+            fi
+workflows:
+  version: 2
+  build-test-deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+
+      - test:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+
+      - deploy:
+          requires:
+            - build
+            - test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     docker:
       - image: docker:18.02.0-ce-git
-    working_directory: /edge-validator
+    working_directory: /app
     steps:
       - checkout
       - run: git submodule sync
@@ -55,16 +55,13 @@ jobs:
       - run:
           name: Test Code
           command: |
-            mkdir test-reports
-            chown -R 10001:10001 test-reports
-            docker run -v test-reports:/app/ -it app:build \
-              pipenv run \
+            container_id="$(docker run -tid app:build)"
+            docker exec "${container_id}" pipenv run \
                 python -m pytest --junitxml=test-reports/junit.xml tests/
+            docker cp "${container_id}":/app/test-reports test-reports
+            docker stop "${container_id}"
 
       - store_test_results:
-          path: test-reports
-
-      - store_artifacts:
           path: test-reports
 
   deploy:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-.git
 .idea
-mozilla-pipeline-schema/
 .pytest_cache
-resources/data
+/resources

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-resources/
+/resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ MAINTAINER Anthony Miyaguchi <amiyaguchi@mozilla.com>
 
 # bootstrap
 ENV PYTHONUNBUFFERED=1 \
-    PORT=8000 \
-    WEB_CONCURRENCY=1
+    PORT=8000
 
 EXPOSE $PORT
 
+RUN apt-get update && \
+    apt-get --yes install make git
 RUN pip install --upgrade pip
 RUN pip install pipenv
 
@@ -20,5 +21,5 @@ COPY . /app
 
 # start userland
 USER app
-RUN pipenv sync
+RUN make sync
 CMD pipenv run flask run --host 0.0.0.0 --port $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ RUN chown -R app:app /app
 COPY . /app
 
 # start userland
+USER app
 RUN pipenv sync
-CMD pipenv run gunicorn -b 0.0.0.0:$PORT app:app
+CMD pipenv run flask run --host 0.0.0.0 --port $PORT

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,5 @@ report:
 build: sync
 	docker build -t edge-validator:latest .
 
-run:
+serve:
 	docker run -p 8000:8000 -it edge-validator:latest

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ build:
 
 serve:
 	docker run -p 8000:8000 -it edge-validator:latest
+
+shell:
+	docker run -p 8000:8000 -it edge-validator:latest /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ build: sync
 	docker build -t edge-validator:latest .
 
 run:
-	docker run -p 8000:8000 edge-validator:latest
+	docker run -p 8000:8000 -it edge-validator:latest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ report:
 	INCLUDE_DATA=true bash sync.sh
 	pipenv run python report_integration.py
 
-build: sync
+build:
 	docker build -t edge-validator:latest .
 
 serve:

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ name = "pypi"
 [packages]
 Flask = "*"
 python-rapidjson = "*"
-gunicorn = "*"
 dockerflow = "*"
+blinker = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 Flask = "*"
 python-rapidjson = "*"
 gunicorn = "*"
+dockerflow = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e6c057203627d101a89fe60d80f36261e300a348c0949dd9ef71059b4ec8f0c4"
+            "sha256": "3dbadd2f91cf6185b9a5d193029a56ab31a9a6ec8cce2c377c319aedb03391a0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "blinker": {
+            "hashes": [
+                "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+            ],
+            "index": "pypi",
+            "version": "==1.4"
+        },
         "click": {
             "hashes": [
                 "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
@@ -38,14 +45,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
-        },
-        "gunicorn": {
-            "hashes": [
-                "sha256:7ef2b828b335ed58e3b64ffa84caceb0a7dd7c5ca12f217241350dec36a1d5dc",
-                "sha256:bc59005979efb6d2dd7d5ba72d99f8a8422862ad17ff3a16e900684630dd2a10"
-            ],
-            "index": "pypi",
-            "version": "==19.8.1"
         },
         "itsdangerous": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cf10d097346c900e05197b999f27fad0a0fc7d863be04de8d98ba13a19856113"
+            "sha256": "e6c057203627d101a89fe60d80f36261e300a348c0949dd9ef71059b4ec8f0c4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,14 @@
                 "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
             ],
             "version": "==6.7"
+        },
+        "dockerflow": {
+            "hashes": [
+                "sha256:2ea52a904abfda3430ff4f1effc164863b30d2b69f7ecbf92dd672860b0ec423",
+                "sha256:388d02c557968e6957140f7b82f669eac70adf5f570bc7705aa749d220a2e535"
+            ],
+            "index": "pypi",
+            "version": "==2018.4.0"
         },
         "flask": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ validation.
 $ OK_DATA="$(echo '{"payload": {"foo": true, "bar": 1, "baz": "hello world"}}')"
 $ curl -X POST -H "Content-Type: application/json" -d "${OK_DATA}" localhost:8000/submit/testing/test/1
 > OK
+```
 
+The endpoint will return `200 OK` on a successful POST. If the URI is malformed, the validator may return with a
+`404 NOT FOUND`. The response will be `400 BAD` if the posted documented does not pass validation. The status will also
+include the exception that caused the error.
+
+```bash
 $ BAD_DATA="$(echo '{"payload": {"foo": null, "bar": "3", "baz": 55}}')"
 $ curl -X POST -H "Content-Type: application/json" -d "${BAD_DATA}" localhost:8000/submit/testing/test/1
 > BAD: ('type', '#/properties/payload/properties/foo', '#/payload/foo')
 ```
+
+In this example, `payload.foo` should be a boolean and `payload.baz` should be a string. Currently, only the first
+validation exception will be propagated to the user.
+
 
 The exposed port can be changed through the `PORT` environment variable. It is possible to mount a set of local
 json-schemas by mounting a folder structure mirroring `mozilla-services/mozilla-pipeline-schemas` to the container's

--- a/README.md
+++ b/README.md
@@ -6,7 +6,101 @@ A service-endpoint for validating pings against `mozilla-pipeline-schemas`.
 
 See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for motivating background.
 
+## Quickstart
+
+**Warning: prebuilt docker images are not available yet. Please refer to the installation guide further below.**
+
+Start the docker container to start the local service at `localhost:8000`. This will fetch the image from dockerhub.
+```bash
+docker run -it edge-validator:latest
+```
+
+Simply POST to the endpoint to check if a document is valid. The `testing` namespace has an example schema for
+validation.
+
+```bash
+$ OK_DATA="$(echo '{"payload": {"foo": true, "bar": 1, "baz": "hello world"}}')"
+$ curl -X POST -H "Content-Type: application/json" -d "${OK_DATA}" localhost:8000/submit/testing/test/1
+> OK
+
+$ BAD_DATA="$(echo '{"payload": {"foo": null, "bar": "3", "baz": 55}}')"
+$ curl -X POST -H "Content-Type: application/json" -d "${BAD_DATA}" localhost:8000/submit/testing/test/1
+> BAD: ('type', '#/properties/payload/properties/foo', '#/payload/foo')
+```
+
+The exposed port can be changed through the `PORT` environment variable. It is possible to mount a set of local
+json-schemas by mounting a folder structure mirroring `mozilla-services/mozilla-pipeline-schemas` to the container's
+`/app/resources/schemas` directory.
+
+```bash
+$ cd mozilla-pipeline-schemas
+$ docker run -v "$(pwd)"/schemas:/app/resources/schemas -it edge-validator
+```
+
 ## User Guide
+## API
+
+### Generic Ingestion
+
+The generic ingestion specification provides enough context to map the ping to a schema.
+
+The _namespace_ distinguishes
+different data collection systems from each other. Telemetry is the largest consumer of the ingestion system to date.
+The _document type_ differentiates messages in the ingestion pipeline. For example, the schemas of the main and crash
+pings share little overlap. The _document version_ allows for versioning between documents. Finally, the _document id_
+is used to check for duplicates. This is validated in the running pipeline, but not supported here.
+
+```
+POST /submit/<namespace>/<doctype>/<docversion/[<docid>]
+```
+
+The schemas are mounted under the application directory `/app/resources/schemas` with the following convention:
+
+```
+/schemas/<NAMESPACE>/<DOCTYPE>.<DOCVERSION>.schema.json
+```
+
+The following tree shows a subset of the resource directory.
+
+```
+/app/resources
+└── schemas
+    ├── telemetry
+    │   ├── anonymous
+    │   │   └── anonymous.4.schema.json
+    │   ├── core
+    │   │   ├── core.1.schema.json
+    │   │   ├── core.2.schema.json
+    │   │   ├── core.3.schema.json
+    │   │   ├── core.4.schema.json
+    │   │   ├── core.5.schema.json
+    │   │   ├── core.6.schema.json
+    │   │   ├── core.7.schema.json
+    │   │   ├── core.8.schema.json
+    │   │   └── core.9.schema.json
+    │   ├── crash
+    │   │   └── crash.4.schema.json
+    │   ├── main
+    │   │   └── main.4.schema.json
+    │   └─── ...
+    │   │   ├── ...
+    │   │   ├── ...
+    │   │   └── ...
+    └── testing
+        └── test
+            └── test.1.schema.json
+```
+
+### Telemetry Ingestion
+
+The edge-validator implements the Edge Server [POST request
+specification](https://docs.telemetry.mozilla.org/concepts/pipeline/http_edge_spec.html#postput-request) for Firefox
+Telemetry. The validator will reroute the request as a generic ingestion request.
+
+```
+POST /submit/<namespace>/<docid>/<appName>/<appVersion>/<appUpdateChannel>/<appBuildId>
+```
+
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A service-endpoint for validating pings against `mozilla-pipeline-schemas`.
 
+[![CircleCI](https://circleci.com/gh/acmiyaguchi/edge-validator.svg?style=svg)](https://circleci.com/gh/acmiyaguchi/edge-validator)
+
 See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for motivating background.
 
 ## User Guide

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A service-endpoint for validating pings against `mozilla-pipeline-schemas`.
 
 See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for motivating background.
 
-## User Guid
+## User Guide
 ### Installation
 
 ```bash
@@ -26,8 +26,8 @@ $ make sync
 #### serving via docker host (recommended)
 
 ```bash
-$ docker --version  # ensure that docker is installed
-$ make run          # start the service
+$ docker --version          # ensure that docker is installed
+$ make serve                # start the service
 ```
 
 #### serving via local host

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# edge-validator
+
+A service-endpoint for validating pings against `mozilla-pipeline-schemas`.
+
+See [bug 1452166](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166) for motivating background.
+
+## User Guid
+### Installation
+
+```bash
+# clone and set the working directory
+$ git clone https://github.com/acmiyaguchi/edge-validator.git
+$ cd edge-validator
+
+# make sure that the system pip is up to date
+$ pip install --user --upgrade pip
+
+# install pipenv for managing the application environment
+$ pip install --user pipenv
+
+# bootstrap for test and serve
+$ make sync
+```
+
+### Serving
+#### serving via docker host (recommended)
+
+```bash
+$ docker --version  # ensure that docker is installed
+$ make run          # start the service
+```
+
+#### serving via local host
+The docker host automates the following bootstrap process. `pipenv` should be installed on the host system. 
+
+```bash
+$ pipenv shell              # enter the application environment
+$ pipenv sync               # update the environment
+$ flask run --port 8000     # run the application
+```
+
+### Running tests
+
+Unit tests do not require any dependencies and can be run out of the box. The sync command will
+copy the test resources into the application resource folder.
+```bash
+$ make sync
+$ make test
+```
+
+An integration report gives a performance report based on sampled data. Make sure that
+aws is set up correctly.
+
+```bash
+# Run using the local app context
+$ make report
+
+# Run using the docker host
+$ EXTERNAL=1 PORT=800 make report
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ pip install --user --upgrade pip
 # install pipenv for managing the application environment
 $ pip install --user pipenv
 
-# bootstrap for test and serve
+# bootstrap for test/report/serve
 $ make sync
 ```
 
@@ -29,7 +29,8 @@ $ make sync
 
 ```bash
 $ docker --version          # ensure that docker is installed
-$ make serve                # start the service
+$ make build                # build the container
+$ make serve                # start the service on localhost:8000
 ```
 
 #### serving via local host

--- a/app.py
+++ b/app.py
@@ -6,8 +6,11 @@ import os
 
 import rapidjson
 from flask import Flask, request
+from dockerflow.flask import Dockerflow
+
 
 app = Flask(__name__)
+dockerflow = Dockerflow(app)
 
 
 def load_namespace(base, namespace):
@@ -49,7 +52,6 @@ def load_data():
     # Schemas have a naming convention. See `sync.sh` for an example of the ingestion
     # submission format.
     schemas = {}
-
 
     # List the separate data ingestion namespaces
     base = "resources/schemas"

--- a/report_integration.py
+++ b/report_integration.py
@@ -29,15 +29,16 @@ else:
 def validate_sample(namespace, name, messages):
     start = time.time()
     fail = 0
+    doctype = name.split('.batch.json')[0]
     for msg in messages:
-        route = '/' + namespace
+        route = '/submit/{}/{}'.format(namespace, doctype)
         rv = client.post(route,
                          data=msg.encode('utf-8'),
                          content_type='application/json')
-        fail += int(rv.status_code == 400)
+        fail += int(rv.status_code != 200)
     end = time.time()
     total = len(messages)
-    err_rate = fail/float(total)
+    err_rate = fail/float(total)*100
     print(
         "ErrorRate: {:.2f}%\t"
         "Total: {}\t"

--- a/report_integration.py
+++ b/report_integration.py
@@ -8,14 +8,17 @@ import requests
 
 import rapidjson as json
 
-if os.environ.get("DOCKER_TEST"):
+if os.environ.get("EXTERNAL"):
+    host = os.environ.get("HOST", "localhost")
+    port = os.environ.get("PORT", 5000)
+
     class Client:
         @staticmethod
         def post(route, data, content_type):
-            headers={'content-type': content_type}
-            return requests.post("http://localhost:8000" + route,
-                                 data=data,
-                                 headers=headers)
+            headers = {'content-type': content_type}
+            uri = "http://{}:{}{}".format(host, port, route)
+            return requests.post(uri, data=data, headers=headers)
+
     client = Client()
 else:
     from app import app
@@ -29,7 +32,7 @@ def validate_sample(namespace, name, messages):
     for msg in messages:
         route = '/' + namespace
         rv = client.post(route,
-                         data=msg,
+                         data=msg.encode('utf-8'),
                          content_type='application/json')
         fail += int(rv.status_code == 400)
     end = time.time()

--- a/sync.sh
+++ b/sync.sh
@@ -105,4 +105,3 @@ function copy_test_schema {
 sync_schema
 if [[ "${INCLUDE_DATA}" == true ]]; then sync_data; fi
 if [[ "${INCLUDE_TESTS}" == true ]]; then copy_test_schema; fi
-

--- a/sync.sh
+++ b/sync.sh
@@ -23,14 +23,14 @@ data_path="${OUTPUT_PATH}/data"
 schema_path="${OUTPUT_PATH}/schemas"
 
 # Create the resource directory if not exists.
-if [[ ! -d ${data_path} ]]; then
+if [[ ! -d "${data_path}" ]]; then
     echo "Creating the resource path: ${data_path}"
-    mkdir -p ${data_path}
+    mkdir -p "${data_path}"
 fi
 
-if [[ ! -d ${schema_path} ]]; then
+if [[ ! -d "${schema_path}" ]]; then
     echo "Creating the resource path: ${schema_path}"
-    mkdir -p ${schema_path}
+    mkdir -p "${schema_path}"
 fi
 
 function sync_data {
@@ -39,10 +39,10 @@ function sync_data {
     # List all available json samples.
     # ex: amiyaguchi/sanitized-landfill-sample/v1/system_id=telemetry/doc_type=anonymous/*.json
     paths=$(
-        aws s3 ls --recursive $src_data_path |  # recursively list all files 
-        grep .json |                            # find leaf nodes containing sampled documents
-        tr -s ' ' | cut -d ' ' -f4              # get the prefix for the json document
-                                                # aws ls returns multiple spaces, so pass it through tr
+        aws s3 ls --recursive "$src_data_path" |  # recursively list all files
+        grep .json |                              # find leaf nodes containing sampled documents
+        tr -s ' ' | cut -d ' ' -f4                # get the prefix for the json document
+                                                  # aws ls returns multiple spaces, so pass it through tr
     )
 
     echo "Updating local sampled data from ${src_data_path}"
@@ -52,29 +52,29 @@ function sync_data {
     for path in ${paths}; do
         # https://stackoverflow.com/a/4749368
         if [[ -e ${cache} ]]; then
-            if grep -Fxq ${path} ${cache}; then
+            if grep -Fxq "${path}" "${cache}"; then
                 echo "Skipping cached ${path}"
                 continue
             fi
         fi
 
-        system=`echo ${path} | cut -d'/' -f4 | cut -d'=' -f2`
-        doc_type=`echo ${path} | cut -d'/' -f5 | cut -d'=' -f2`
+        system=$(echo "${path}" | cut -d'/' -f4 | cut -d'=' -f2)
+        doc_type=$(echo "${path}" | cut -d'/' -f5 | cut -d'=' -f2)
         
         system_dir="${data_path}/${system}"
         filename="${doc_type}.batch.json"
         
         # make the system directory e.g. telemetry if not exists
-        if [[ ! -d ${system_dir} ]]; then
-           mkdir -p ${system_dir}
+        if [[ ! -d "${system_dir}" ]]; then
+           mkdir -p "${system_dir}"
         fi
 
         # copy and overwrite any existing data
-        aws s3 cp s3://${SRC_DATA_BUCKET}/${path} ${system_dir}/${filename}
+        aws s3 cp "s3://${SRC_DATA_BUCKET}/${path}" "${system_dir}/${filename}"
     done
 
     # cache metadata
-    echo ${paths} | tr ' ' '\n' > ${cache}
+    echo "${paths}" | tr ' ' '\n' > "${cache}"
 }
 
 function sync_schema {
@@ -89,17 +89,17 @@ function sync_schema {
 
     # print out branch information if applicable
     if [[ -e "${MPS_ROOT}/.git" ]]; then
-        pushd .; cd ${MPS_ROOT}
+        pushd .; cd "${MPS_ROOT}"
         git --no-pager log -n1
         popd
     fi
 
-    cp --recursive --verbose ${src_schema_path}/* ${schema_path}/
+    cp --recursive --verbose "${src_schema_path}"/* "${schema_path}"/
 }
 
 function copy_test_schema {
     echo "Copying testing schemas"
-    cp --recursive --verbose tests/resources/schemas/* ${schema_path}/
+    cp --recursive --verbose "tests/resources/schemas"/* "${schema_path}"/
 }
 
 sync_schema

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    yield app.test_client()
+
+
+@pytest.fixture
+def ping():
+    return {
+        "type": "test",
+        "id": "some-uuid-string",
+        "creationDate": "2018-05-07T20:57:32.023Z",
+        "version": 1,
+        "payload": {
+            "foo": True,
+            "bar": 7,
+            "baz": "today is sunny"
+        }
+    }

--- a/tests/resources/schemas/testing/test/test.1.schema.json
+++ b/tests/resources/schemas/testing/test/test.1.schema.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "properties": {
+        "payload": {
+            "type": "object",
+            "properties": {
+                "foo": {"type": "boolean"},
+                "bar": {"type": "integer"},
+                "baz": {"type": "string"}
+            },
+            "required": ["foo", "bar"]
+        }
+    },
+    "required": ["payload"]
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,82 +1,57 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from uuid import uuid4
 
-import rapidjson as json
 import pytest
-from app import app
+import rapidjson as json
+
+from .utils import GenericURISpec, build_route
 
 
 @pytest.fixture
-def client():
-    app.config['TESTING'] = True
-    yield app.test_client()
+def route():
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=1,
+                          docid=str(uuid4()))
+    return build_route(spec)
 
 
-@pytest.fixture
-def ping():
-    return {
-        "type": "test",
-        "id": "some-uuid-string",
-        "creationDate": "2018-05-07T20:57:32.023Z",
-        "version": 1,
-        "payload": {
-            "foo": True,
-            "bar": 7,
-            "baz": "today is sunny"
-        }
-    }
-
-
-def test_server_mounts_testing_namespace(client, ping):
-    rv = client.post('/submit/testing/test/1',
+def test_server_mounts_testing_namespace(client, ping, route):
+    rv = client.post(route,
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200
 
 
-def test_server_redirects_missing_version(client, ping):
-    rv = client.post('/submit/testing/test',
-                     data=json.dumps(ping),
-                     content_type='application/json')
-    assert rv.status_code == 200
-
-
-def test_ping_omit_type(client, ping):
-    del ping["type"]
-    rv = client.post('/submit/testing',
-                     data=json.dumps(ping),
-                     content_type='application/json')
-    assert rv.status_code == 404
-
-
-def test_ping_omit_payload(client, ping):
+def test_ping_omit_payload(client, ping, route):
     del ping["payload"]
-    rv = client.post('/submit/testing/test/1',
+    rv = client.post(route,
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 400
 
 
-def test_ping_omit_required(client, ping):
+def test_ping_omit_required(client, ping, route):
     del ping["payload"]["foo"]
-    rv = client.post('/submit/testing/test/1',
+    rv = client.post(route,
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 400
 
 
-def test_ping_omit_optional(client, ping):
+def test_ping_omit_optional(client, ping, route):
     del ping["payload"]["baz"]
-    rv = client.post('/submit/testing/test/1',
+    rv = client.post(route,
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200
 
 
-def test_ping_wrong_type(client, ping):
+def test_ping_wrong_type(client, ping, route):
     ping["payload"]["baz"]
-    rv = client.post('/submit/testing/test/1',
+    rv = client.post(route,
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,7 +29,14 @@ def ping():
 
 
 def test_server_mounts_testing_namespace(client, ping):
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing/test/1',
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
+def test_server_redirects_missing_version(client, ping):
+    rv = client.post('/submit/testing/test',
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200
@@ -37,15 +44,15 @@ def test_server_mounts_testing_namespace(client, ping):
 
 def test_ping_omit_type(client, ping):
     del ping["type"]
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing',
                      data=json.dumps(ping),
                      content_type='application/json')
-    assert rv.status_code == 400
+    assert rv.status_code == 404
 
 
 def test_ping_omit_payload(client, ping):
     del ping["payload"]
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing/test/1',
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 400
@@ -53,7 +60,7 @@ def test_ping_omit_payload(client, ping):
 
 def test_ping_omit_required(client, ping):
     del ping["payload"]["foo"]
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing/test/1',
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 400
@@ -61,7 +68,7 @@ def test_ping_omit_required(client, ping):
 
 def test_ping_omit_optional(client, ping):
     del ping["payload"]["baz"]
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing/test/1',
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200
@@ -69,7 +76,7 @@ def test_ping_omit_optional(client, ping):
 
 def test_ping_wrong_type(client, ping):
     ping["payload"]["baz"]
-    rv = client.post('/testing',
+    rv = client.post('/submit/testing/test/1',
                      data=json.dumps(ping),
                      content_type='application/json')
     assert rv.status_code == 200

--- a/tests/test_generic_ingestion.py
+++ b/tests/test_generic_ingestion.py
@@ -1,0 +1,107 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from uuid import uuid4
+
+import rapidjson as json
+
+from .utils import GenericURISpec, build_route
+
+
+def test_generic_ingestion_ok(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=1,
+                          docid=str(uuid4()))
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
+def test_generic_ingestion_omit_docid(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=1,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
+def test_generic_ingestion_invalid_uuid_docid(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=1,
+                          docid='definitely-not-a-uuid')
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 404
+
+
+def test_generic_ingestion_omit_version(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=None,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
+def test_generic_ingestion_nonexisting_version(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion=999,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 400
+
+
+def test_generic_ingestion_bad_version(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test',
+                          docversion='v1',
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 404
+
+
+def test_generic_ingestion_omit_type(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype=None,
+                          docversion=None,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 404
+
+
+def test_generic_ingestion_nonexisting_type(client, ping):
+    spec = GenericURISpec(namespace='testing',
+                          doctype='test-nonexisting-doctype',
+                          docversion=1,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 400
+
+
+def test_generic_ingestion_nonexisting_namespace(client, ping):
+    spec = GenericURISpec(namespace='test-nonexisting-namespace',
+                          doctype='test',
+                          docversion=1,
+                          docid=None)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 400

--- a/tests/test_telemetry_ingestion.py
+++ b/tests/test_telemetry_ingestion.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from uuid import uuid4
+
+import pytest
+import rapidjson as json
+
+from .utils import TelemetryURISpec, build_route
+
+
+@pytest.fixture
+def default_values():
+    return {
+        'namespace': 'testing',
+        'docid': str(uuid4()),
+        'doctype': 'test',
+        'appName': 'Firefox',
+        'appVersion': '61.0a1',
+        'appUpdateChannel': 'nightly',
+        'appBuildId': '20180328030202',
+    }
+
+
+def test_telemetry_ingestion_ok(client, ping, default_values):
+    spec = TelemetryURISpec(**default_values)
+    rv = client.post(build_route(spec),
+                     data=json.dumps(ping),
+                     content_type='application/json')
+    assert rv.status_code == 200
+
+
+def test_generic_ingestion_omit_routes(client, ping, default_values):
+    for key in default_values.keys():
+        # create a new dictionary with the single key nulled out
+        overwritten_dict = {**default_values, **{key: None}}
+        spec = TelemetryURISpec(**overwritten_dict)
+        rv = client.post(build_route(spec),
+                         data=json.dumps(ping),
+                         content_type='application/json')
+        assert rv.status_code != 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from collections import namedtuple
+
+
+GenericURISpec = namedtuple('GenericURISpec', [
+    'namespace',
+    'doctype',
+    'docversion',
+    'docid',
+])
+
+
+# See: https://docs.telemetry.mozilla.org/concepts/pipeline/http_edge_spec.html#postput-request
+TelemetryURISpec = namedtuple('GenericURISpec', [
+    'namespace',
+    'docid',
+    'doctype',
+    'appName',
+    'appVersion',
+    'appUpdateChannel',
+    'appBuildId'
+])
+
+
+def build_route(spec):
+    # drop everything after the first None
+    if None in spec:
+        spec = spec[:spec.index(None)]
+    return '/'.join(['/submit'] + list(map(str, spec)))

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "source": "https://github.com/acmiyaguchi/edge-validator",
-  "version": "stub",
+  "version": "1.0",
   "commit": "stub"
 }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/acmiyaguchi/edge-validator",
+  "version": "stub",
+  "commit": "stub"
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1452166)

Follow the build instructions in the README or down below for running the integration report to verify behavior.

```bash
git clone https://github.com/acmiyaguchi/edge-validator.git
cd edge-validator && git checkout origin/dev
git submodule sync
git submodule update --init

# make sure pip is up to date and install pipenv
pip install --user --upgrade pip
pip install --user pipenv

# do you have docker installed?
docker --version

# do you have access to s3?
aws s3 ls s3://telemetry-test-bucket

# 7 passing tests
make sync
make test

# in one terminal
make build
make server

# in another terminal
EXTERNAL=1 PORT=8000 make report

# manually CURLing data

data="$(cat resources/data/telemetry/main.batch.json | head -n1 | jq -r .content)"
curl -H "Content-Type: application/json" \
       -X POST \
       -d "$data" \
       localhost:8000/submit/telemetry/main
```
The results should be something like the following:
```
...
ErrorRate: 100.00%	Total: 1000	Time: 0.8 seconds	DocType: telemetry.heartbeat.batch.json
ErrorRate: 73.80%	Total: 1000	Time: 0.7 seconds	DocType: telemetry.core.batch.json
ErrorRate: 0.00%	Total: 1000	Time: 0.9 seconds	DocType: telemetry.new-profile.batch.json
...
```